### PR TITLE
Improved compatability with other boards & add Attiny85

### DIFF
--- a/DigitalIO/src/PinIO.h
+++ b/DigitalIO/src/PinIO.h
@@ -31,6 +31,7 @@
 #include <Arduino.h>
 #include <util/atomic.h>
 #include <avr/io.h>
+#include <GpioPinMap.h>
 //------------------------------------------------------------------------------
 /**
  * @class PinIO

--- a/DigitalIO/src/boards/ATtiny85GpioPinMap.h
+++ b/DigitalIO/src/boards/ATtiny85GpioPinMap.h
@@ -1,0 +1,17 @@
+#ifndef ATtiny85GpioPinMap_h
+#define ATtiny85GpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 6
+#endif
+
+// ATtiny85 and 45
+static const GpioPinMap_t GpioPinMap[] = {
+  {&DDRB, &PINB, &PORTB, 0},  // B0  0
+  {&DDRB, &PINB, &PORTB, 1},  // B1  1
+  {&DDRB, &PINB, &PORTB, 2},  // B2  2
+  {&DDRB, &PINB, &PORTB, 3},  // B3  3
+  {&DDRB, &PINB, &PORTB, 4},  // B4  4
+  {&DDRB, &PINB, &PORTB, 5},  // B5  5
+};
+#endif  // ATtiny85GpioPinMap_h

--- a/DigitalIO/src/boards/AvrDevelopersGpioPinMap.h
+++ b/DigitalIO/src/boards/AvrDevelopersGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef AvrDevelopersGpioPinMap_h
 #define AvrDevelopersGpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 32
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1

--- a/DigitalIO/src/boards/BobuinoGpioPinMap.h
+++ b/DigitalIO/src/boards/BobuinoGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef BobuinoGpioPinMap_h
 #define BobuinoGpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 32
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1

--- a/DigitalIO/src/boards/GpioPinMap.h
+++ b/DigitalIO/src/boards/GpioPinMap.h
@@ -19,7 +19,10 @@
  */
 #ifndef GpioPinMap_h
 #define GpioPinMap_h
-#if defined(__AVR_ATmega168__)\
+#if defined(__AVR_ATtiny45__)\
+||defined(__AVR_ATtiny85__)
+#include "ATtiny85GpioPinMap.h"
+#elif defined(__AVR_ATmega168__)\
 ||defined(__AVR_ATmega168P__)\
 ||defined(__AVR_ATmega328P__)
 // 168 and 328 Arduinos

--- a/DigitalIO/src/boards/LeonardoGpioPinMap.h
+++ b/DigitalIO/src/boards/LeonardoGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef LeonardoGpioPinMap_h
 #define LeonardoGpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 30
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 2),  // D0
   GPIO_PIN(D, 3),  // D1

--- a/DigitalIO/src/boards/MegaGpioPinMap.h
+++ b/DigitalIO/src/boards/MegaGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef MegaGpioPinMap_h
 #define MegaGpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 70
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(E, 0),  // D0
   GPIO_PIN(E, 1),  // D1

--- a/DigitalIO/src/boards/SleepingBeautyGpioPinMap.h
+++ b/DigitalIO/src/boards/SleepingBeautyGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef SleepingBeautyGpioPinMap_h
 #define SleepingBeautyGpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 32
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 0),  // D0
   GPIO_PIN(D, 1),  // D1

--- a/DigitalIO/src/boards/Standard1284GpioPinMap.h
+++ b/DigitalIO/src/boards/Standard1284GpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef Standard1284GpioPinMap_h
 #define Standard1284GpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 32
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1

--- a/DigitalIO/src/boards/Teensy2GpioPinMap.h
+++ b/DigitalIO/src/boards/Teensy2GpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef Teensy2GpioPinMap_h
 #define Teensy2GpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 25
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1

--- a/DigitalIO/src/boards/Teensy2ppGpioPinMap.h
+++ b/DigitalIO/src/boards/Teensy2ppGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef Teensypp2GpioPinMap_h
 #define Teensypp2GpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 46
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 0),  // D0
   GPIO_PIN(D, 1),  // D1

--- a/DigitalIO/src/boards/UnoGpioPinMap.h
+++ b/DigitalIO/src/boards/UnoGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef UnoGpioPinMap_h
 #define UnoGpioPinMap_h
+
+#ifndef NUM_DIGITAL_PINS
+#define NUM_DIGITAL_PINS 20
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 0),  // D0
   GPIO_PIN(D, 1),  // D1


### PR DESCRIPTION
- Add ATtiny85/ATtiny45 pin mapping
- Add conditional (i.e. if not already defined) NUM_DIGITAL_PINS defines to all boards. Note: This macro is not defined for all boards that contain the chips in the Gpio pin maps
- Add #include <GpioPinMap.h> to PinIO.h as PinIO.cpp requires knowledge of NUM_DIGITAL_PINS
